### PR TITLE
Fix a race condition where retrieved items from cache could be expired

### DIFF
--- a/flipper/contrib/cached.py
+++ b/flipper/contrib/cached.py
@@ -28,8 +28,9 @@ class CachedFeatureFlagStore(AbstractFeatureFlagStore):
         return item
 
     def get(self, feature_name: str) -> Optional[FeatureFlagStoreItem]:
-        if feature_name in self._cache:
-            return self._cache[feature_name]
+        cached = self._cache.get(feature_name)
+        if cached is not None:
+            return cached
 
         item = self._store.get(feature_name)
         self._cache.set(feature_name, item, **self._cache_options)


### PR DESCRIPTION
See: https://sentry.io/carta/app/issues/813687012

I think there was a race condition in the `CachedFeatureFlagStore`. We were doing this:

```python
if feature_name in self._cache:
    return self._cache[feature_name]
```

If we call this at the exact same time that the ttl expires then the second line will return `None`. This fixes that by reading the value from the cache, checking if that value is `None`, and then returning the cached value.

If anyone wants to understand why this is a problem take a look at the LRU cache implementation here: https://github.com/arnov/lru-ttl/blob/master/lruttl/lru.py#L39