### PR TITLE
Use redis mget method for bulk fetches in list method

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 combine_as_imports=True
 line_length=88
-known_third_party = boto3,fakeredis,lruttl,moto,setuptools,thrift
+known_third_party = boto3,fakeredis,lruttl,moto,redis,setuptools,thrift

--- a/flipper/contrib/util/iter.py
+++ b/flipper/contrib/util/iter.py
@@ -1,0 +1,24 @@
+# Copyright 2018 eShares, Inc. dba Carta, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from itertools import islice
+from typing import Iterable, Iterator
+
+
+def batchify(iterable: Iterable, chunk_size: int) -> Iterator[list]:
+    it = iter(iterable)
+    while True:
+        chunk = list(islice(it, chunk_size))
+        if not chunk:
+            return
+        yield chunk

--- a/tests/contrib/test_redis.py
+++ b/tests/contrib/test_redis.py
@@ -224,6 +224,23 @@ class TestList(BaseTest):
         for feature_name in actual:
             self.assertTrue(feature_name in feature_names)
 
+    def test_when_batch_size_is_set_to_a_value_smaller_than_number_of_keys_still_returns_everything(  # noqa: E501
+        self
+    ):
+        feature_names = [self.txt() for _ in range(10)]
+
+        store = RedisFeatureFlagStore(self.redis, list_method_batch_size=3)
+
+        for name in feature_names:
+            store.create(name)
+
+        results = store.list()
+        actual = [item.feature_name for item in results]
+
+        self.assertEqual(len(feature_names), len(actual))
+        for feature_name in actual:
+            self.assertTrue(feature_name in feature_names)
+
 
 class TestSetMeta(BaseTest):
     def test_sets_client_data_correctly(self):

--- a/tests/contrib/util/test_iter.py
+++ b/tests/contrib/util/test_iter.py
@@ -1,0 +1,40 @@
+import unittest
+
+from flipper.contrib.util.iter import batchify
+
+
+class TestBatchify(unittest.TestCase):
+    def test_it_breaks_an_iterable_into_chunks(self):
+        iterable = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+        chunks = list(batchify(iterable, 2))
+
+        self.assertEqual(5, len(chunks))
+
+    def test_it_breaks_an_iterator_into_chunks(self):
+        iterable = (x for x in range(10))
+
+        chunks = list(batchify(iterable, 2))
+
+        self.assertEqual(5, len(chunks))
+
+    def test_when_list_does_not_divide_evenly_you_get_one_extra_chunk(self):
+        iterable = range(11)
+
+        chunks = list(batchify(iterable, 2))
+
+        self.assertEqual(6, len(chunks))
+
+    def test_chunks_contain_correct_items(self):
+        iterable = range(11)
+
+        chunks = list(batchify(iterable, 2))
+
+        self.assertEqual([[0, 1], [2, 3], [4, 5], [6, 7], [8, 9], [10]], chunks)
+
+    def test_when_chunk_size_is_larger_than_iterable_size_returns_one_chunk(self):
+        iterable = range(10)
+
+        chunks = list(batchify(iterable, 20))
+
+        self.assertEqual(1, len(chunks))


### PR DESCRIPTION
Fixes #20 

The `list` operation is less efficient than it could be. The original implementation did one `GET` to redis for each flag returned from `list`. Redis supports bulk get with the `MGET` method. This PR switches to using `MGET` instead of `GET`.

It works by enumerating all the flags. Rather than load all the flags into memory I batch the flag names into chunks of 100. Then I do an `MGET` for 100 flags at a time and yield those one at a time. The batch size is configurable.