### PR TITLE
Add event emitter functionality

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 combine_as_imports=True
 line_length=88
-known_third_party = boto3,fakeredis,lruttl,moto,redis,setuptools,thrift
+known_third_party = boto3,fakeredis,lruttl,moto,pyee,pytest,redis,setuptools,thrift

--- a/flipper/__init__.py
+++ b/flipper/__init__.py
@@ -23,7 +23,7 @@ from .contrib import (
     S3FeatureFlagStore,
     ThriftRPCFeatureFlagStore,
 )
-from .flag import FlagDoesNotExistError
+from .exceptions import FlagDoesNotExistError
 
 __all__ = [
     "CachedFeatureFlagStore",

--- a/flipper/client.py
+++ b/flipper/client.py
@@ -11,20 +11,28 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from typing import Iterator, Optional
+from typing import Iterator, Optional, cast
 
 from .bucketing.base import AbstractBucketer
 from .conditions import Condition
 from .contrib.interface import AbstractFeatureFlagStore
+from .contrib.storage import FeatureFlagStoreItem, FeatureFlagStoreMeta
+from .exceptions import FlagDoesNotExistError
 from .flag import FeatureFlag
+
+
+def flag_must_exist(fn):
+    def wrapper(self, feature_name: str, *args, **kwargs):
+        if not self.exists(feature_name):
+            raise FlagDoesNotExistError()
+        return fn(self, feature_name, *args, **kwargs)
+
+    return wrapper
 
 
 class FeatureFlagClient:
     def __init__(self, store: AbstractFeatureFlagStore) -> None:
         self._store = store
-
-    def is_enabled(self, feature_name: str, **conditions) -> bool:
-        return self.get(feature_name).is_enabled(**conditions)
 
     def create(
         self,
@@ -35,20 +43,17 @@ class FeatureFlagClient:
         self._store.create(feature_name, is_enabled=is_enabled, client_data=client_data)
         return self.get(feature_name)
 
-    def exists(self, feature_name: str) -> bool:
+    def is_enabled(self, feature_name: str, default=False, **conditions) -> bool:
+        item = self._store.get(feature_name)
+        if item is None:
+            return default
+        return item.is_enabled(**conditions)
+
+    def exists(self, feature_name: str):
         return self._store.get(feature_name) is not None
 
     def get(self, feature_name: str) -> FeatureFlag:
-        return FeatureFlag(feature_name, self._store)
-
-    def destroy(self, feature_name: str):
-        return self.get(feature_name).destroy()
-
-    def enable(self, feature_name: str):
-        return self.get(feature_name).enable()
-
-    def disable(self, feature_name: str):
-        return self.get(feature_name).disable()
+        return FeatureFlag(feature_name, self)
 
     def list(
         self, limit: Optional[int] = None, offset: int = 0
@@ -56,17 +61,45 @@ class FeatureFlagClient:
         for item in self._store.list(limit=limit, offset=offset):
             yield self.get(item.feature_name)
 
+    @flag_must_exist
+    def enable(self, feature_name: str):
+        self._store.set(feature_name, True)
+
+    @flag_must_exist
+    def disable(self, feature_name: str):
+        self._store.set(feature_name, False)
+
+    @flag_must_exist
+    def destroy(self, feature_name: str):
+        self._store.delete(feature_name)
+
+    @flag_must_exist
+    def add_condition(self, feature_name: str, condition: Condition):
+        meta = FeatureFlagStoreMeta.from_dict(self.get_meta(feature_name))
+
+        meta.conditions.append(condition)
+
+        self._store.set_meta(feature_name, meta)
+
+    @flag_must_exist
     def set_client_data(self, feature_name: str, client_data: dict):
-        return self.get(feature_name).set_client_data(client_data)
+        meta = FeatureFlagStoreMeta.from_dict(self.get_meta(feature_name))
+
+        meta.update(client_data=client_data)
+
+        self._store.set_meta(feature_name, meta)
 
     def get_client_data(self, feature_name: str) -> dict:
-        return self.get(feature_name).get_client_data()
+        return self.get_meta(feature_name)["client_data"]
 
+    @flag_must_exist
     def get_meta(self, feature_name: str) -> dict:
-        return self.get(feature_name).get_meta()
+        return cast(FeatureFlagStoreItem, self._store.get(feature_name)).meta
 
-    def add_condition(self, feature_name: str, condition: Condition):
-        return self.get(feature_name).add_condition(condition)
-
+    @flag_must_exist
     def set_bucketer(self, feature_name: str, bucketer: AbstractBucketer):
-        return self.get(feature_name).set_bucketer(bucketer)
+        meta = FeatureFlagStoreMeta.from_dict(self.get_meta(feature_name))
+
+        meta.update(bucketer=bucketer)
+
+        self._store.set_meta(feature_name, meta)

--- a/flipper/contrib/thrift.py
+++ b/flipper/contrib/thrift.py
@@ -27,7 +27,7 @@ from ..bucketing import BucketerFactory
 from ..bucketing.base import AbstractBucketer
 from ..conditions import Condition
 from ..conditions.check import Check
-from ..flag import FlagDoesNotExistError
+from ..exceptions import FlagDoesNotExistError
 
 
 class ThriftRPCFeatureFlagStore(AbstractFeatureFlagStore):

--- a/flipper/events/__init__.py
+++ b/flipper/events/__init__.py
@@ -1,0 +1,23 @@
+# Copyright 2018 eShares, Inc. dba Carta, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from .emitter import FlipperEventEmitter, IEventEmitter
+from .subscriber import FlipperEventSubscriber
+from .types import EventType
+
+__all__ = [
+    "FlipperEventEmitter",
+    "IEventEmitter",
+    "FlipperEventSubscriber",
+    "EventType",
+]

--- a/flipper/events/emitter.py
+++ b/flipper/events/emitter.py
@@ -1,0 +1,55 @@
+# Copyright 2018 eShares, Inc. dba Carta, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from abc import ABCMeta, abstractmethod
+from typing import Any, Callable, Optional
+
+from pyee import BaseEventEmitter
+
+from .subscriber import FlipperEventSubscriber
+from .types import EventType
+
+
+class IEventEmitter(metaclass=ABCMeta):
+    @abstractmethod
+    def emit(self, event: Any, *args, **kwargs) -> bool:
+        pass
+
+    @abstractmethod
+    def on(self, event: Any, f: Optional[Callable] = None) -> bool:
+        pass
+
+    @abstractmethod
+    def remove_listener(self, event: Any, f: Callable) -> None:
+        pass
+
+    @abstractmethod
+    def remove_subscriber(self, subscriber: FlipperEventSubscriber) -> None:
+        pass
+
+
+class FlipperEventEmitter(BaseEventEmitter, IEventEmitter):
+    def register_subscriber(self, subscriber: FlipperEventSubscriber) -> None:
+        for event_type in EventType:
+            self.on(event_type, f=self._handler_method_for(subscriber, event_type))
+
+    def _handler_method_for(
+        self, subscriber: FlipperEventSubscriber, event_type: EventType
+    ) -> Callable:
+        return getattr(subscriber, "on_%s" % event_type.value)
+
+    def remove_subscriber(self, subscriber: FlipperEventSubscriber) -> None:
+        for event_type in EventType:
+            self.remove_listener(
+                event_type, f=self._handler_method_for(subscriber, event_type)
+            )

--- a/flipper/events/subscriber.py
+++ b/flipper/events/subscriber.py
@@ -1,0 +1,65 @@
+# Copyright 2018 eShares, Inc. dba Carta, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from typing import Optional
+
+from flipper.bucketing.base import AbstractBucketer
+from flipper.conditions import Condition
+
+
+class FlipperEventSubscriber:
+    def on_pre_create(
+        self, flag_name: str, is_enabled: bool, client_data: Optional[dict]
+    ):
+        pass
+
+    def on_post_create(
+        self, flag_name: str, is_enabled: bool, client_data: Optional[dict]
+    ):
+        pass
+
+    def on_pre_enable(self, flag_name: str):
+        pass
+
+    def on_post_enable(self, flag_name: str):
+        pass
+
+    def on_pre_disable(self, flag_name: str):
+        pass
+
+    def on_post_disable(self, flag_name: str):
+        pass
+
+    def on_pre_destroy(self, flag_name: str):
+        pass
+
+    def on_post_destroy(self, flag_name: str):
+        pass
+
+    def on_pre_add_condition(self, flag_name: str, condition: Condition):
+        pass
+
+    def on_post_add_condition(self, flag_name: str, condition: Condition):
+        pass
+
+    def on_pre_set_client_data(self, flag_name: str, client_data: dict):
+        pass
+
+    def on_post_set_client_data(self, flag_name: str, client_data: dict):
+        pass
+
+    def on_pre_set_bucketer(self, flag_name: str, bucketer: AbstractBucketer):
+        pass
+
+    def on_post_set_bucketer(self, flag_name: str, bucketer: AbstractBucketer):
+        pass

--- a/flipper/events/types.py
+++ b/flipper/events/types.py
@@ -1,0 +1,37 @@
+# Copyright 2018 eShares, Inc. dba Carta, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import enum
+
+
+class EventType(enum.Enum):
+    PRE_CREATE = "pre_create"
+    POST_CREATE = "post_create"
+
+    PRE_ENABLE = "pre_enable"
+    POST_ENABLE = "post_enable"
+
+    PRE_DISABLE = "pre_disable"
+    POST_DISABLE = "post_disable"
+
+    PRE_DESTROY = "pre_destroy"
+    POST_DESTROY = "post_destroy"
+
+    PRE_ADD_CONDITION = "pre_add_condition"
+    POST_ADD_CONDITION = "post_add_condition"
+
+    PRE_SET_CLIENT_DATA = "pre_set_client_data"
+    POST_SET_CLIENT_DATA = "post_set_client_data"
+
+    PRE_SET_BUCKETER = "pre_set_bucketer"
+    POST_SET_BUCKETER = "post_set_bucketer"

--- a/flipper/exceptions.py
+++ b/flipper/exceptions.py
@@ -1,0 +1,16 @@
+# Copyright 2018 eShares, Inc. dba Carta, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+
+class FlagDoesNotExistError(Exception):
+    pass

--- a/tests/events/test_emitter.py
+++ b/tests/events/test_emitter.py
@@ -1,0 +1,75 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from flipper.events import EventType, FlipperEventEmitter, FlipperEventSubscriber
+
+
+class DummySubscriber(FlipperEventSubscriber):
+    def __init__(self, mock):
+        self._mock = mock
+
+    def on_pre_create(self, *args, **kwargs):
+        self._mock.on_pre_create(*args, **kwargs)
+
+    def on_post_create(self, *args, **kwargs):
+        self._mock.on_post_create(*args, **kwargs)
+
+    def on_pre_enable(self, *args, **kwargs):
+        self._mock.on_pre_enable(*args, **kwargs)
+
+    def on_post_enable(self, *args, **kwargs):
+        self._mock.on_post_enable(*args, **kwargs)
+
+    def on_pre_disable(self, *args, **kwargs):
+        self._mock.on_pre_disable(*args, **kwargs)
+
+    def on_post_disable(self, *args, **kwargs):
+        self._mock.on_post_disable(*args, **kwargs)
+
+    def on_pre_destroy(self, *args, **kwargs):
+        self._mock.on_pre_destroy(*args, **kwargs)
+
+    def on_post_destroy(self, *args, **kwargs):
+        self._mock.on_post_destroy(*args, **kwargs)
+
+    def on_pre_add_condition(self, *args, **kwargs):
+        self._mock.on_pre_add_condition(*args, **kwargs)
+
+    def on_post_add_condition(self, *args, **kwargs):
+        self._mock.on_post_add_condition(*args, **kwargs)
+
+    def on_pre_set_client_data(self, *args, **kwargs):
+        self._mock.on_pre_set_client_data(*args, **kwargs)
+
+    def on_post_set_client_data(self, *args, **kwargs):
+        self._mock.on_post_set_client_data(*args, **kwargs)
+
+    def on_pre_set_bucketer(self, *args, **kwargs):
+        self._mock.on_pre_set_bucketer(*args, **kwargs)
+
+    def on_post_set_bucketer(self, *args, **kwargs):
+        self._mock.on_post_set_bucketer(*args, **kwargs)
+
+
+class TestRegisterSubscriber:
+    @pytest.mark.parametrize("event_type", list(EventType))
+    def test_all_listeners_get_registered(self, event_type):
+        mock = MagicMock()
+        subscriber = DummySubscriber(mock)
+        events = FlipperEventEmitter()
+        events.register_subscriber(subscriber)
+        events.emit(event_type)
+        getattr(mock, "on_%s" % event_type.value).assert_called_once_with()
+
+
+class TestRemoveSubscriber:
+    @pytest.mark.parametrize("event_type", list(EventType))
+    def test_all_listeners_get_removed(self, event_type):
+        mock = MagicMock()
+        subscriber = DummySubscriber(mock)
+        events = FlipperEventEmitter()
+        events.register_subscriber(subscriber)
+        events.remove_subscriber(subscriber)
+        events.emit(event_type)
+        getattr(mock, "on_%s" % event_type.value).assert_not_called()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,7 +5,8 @@ from uuid import uuid4
 from flipper import Condition, FeatureFlagClient, MemoryFeatureFlagStore
 from flipper.bucketing import Percentage, PercentageBucketer
 from flipper.contrib.storage import FeatureFlagStoreMeta
-from flipper.flag import FeatureFlag, FlagDoesNotExistError
+from flipper.exceptions import FlagDoesNotExistError
+from flipper.flag import FeatureFlag
 
 
 class BaseTest(unittest.TestCase):


### PR DESCRIPTION
I wanted a way to hook into the internal events within the client. To implement this I instantiate an event emitter whenever you construct a client. The client then emits events on this emitter before and after every write-based operation. You can then register subscribers with this event emitter to react to whatever you decide you want to react to.

I had to refactor the core client/flag classes to make this feasible, so you probably should review both commits individually to understand the changes, otherwise it might not make sense. I think this refactor actually makes a lot of sense and the core is a bit cleaner as a result.