### PR TITLE
set conditions on client

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,6 +747,8 @@ Flipper ships with a system for hooking into events. It is set up as an event em
 - `POST_DESTROY`
 - `PRE_ADD_CONDITION`
 - `POST_ADD_CONDITION`
+- `PRE_SET_CONDITIONS`
+- `POST_SET_CONDITIONS`
 - `PRE_SET_CLIENT_DATA`
 - `POST_SET_CLIENT_DATA`
 - `PRE_SET_BUCKETER`

--- a/flipper/client.py
+++ b/flipper/client.py
@@ -11,7 +11,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from typing import Iterator, Optional, cast
+from typing import Iterator, Optional, cast, Iterable
 
 from .bucketing.base import AbstractBucketer
 from .conditions import Condition
@@ -144,3 +144,23 @@ class FeatureFlagClient:
         self._event_emitter.emit(EventType.PRE_SET_BUCKETER, feature_name, bucketer)
         self._store.set_meta(feature_name, meta)
         self._event_emitter.emit(EventType.POST_SET_BUCKETER, feature_name, bucketer)
+
+    @flag_must_exist
+    def set_conditions(self, feature_name: str,
+                       conditions: Iterable[Condition]):
+        '''
+        This method will set the conditions to the feature flag.
+        Contrary to `add_conditions` it will not append the condition, but will
+        update the whole condition set the the new values provided.
+        '''
+        meta = FeatureFlagStoreMeta.from_dict(self.get_meta(feature_name))
+
+        meta.conditions = list(conditions)
+
+        self._event_emitter.emit(EventType.PRE_SET_CONDITIONS,
+                                 feature_name,
+                                 conditions)
+        self._store.set_meta(feature_name, meta)
+        self._event_emitter.emit(EventType.POST_SET_CONDITIONS,
+                                 feature_name,
+                                 conditions)

--- a/flipper/client.py
+++ b/flipper/client.py
@@ -11,7 +11,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from typing import Iterator, Optional, cast, Iterable
+from typing import Iterable, Iterator, Optional, cast
 
 from .bucketing.base import AbstractBucketer
 from .conditions import Condition
@@ -146,21 +146,18 @@ class FeatureFlagClient:
         self._event_emitter.emit(EventType.POST_SET_BUCKETER, feature_name, bucketer)
 
     @flag_must_exist
-    def set_conditions(self, feature_name: str,
-                       conditions: Iterable[Condition]):
-        '''
+    def set_conditions(self, feature_name: str, conditions: Iterable[Condition]):
+        """
         This method will set the conditions to the feature flag.
         Contrary to `add_conditions` it will not append the condition, but will
         update the whole condition set the the new values provided.
-        '''
+        """
         meta = FeatureFlagStoreMeta.from_dict(self.get_meta(feature_name))
 
         meta.conditions = list(conditions)
 
-        self._event_emitter.emit(EventType.PRE_SET_CONDITIONS,
-                                 feature_name,
-                                 conditions)
+        self._event_emitter.emit(EventType.PRE_SET_CONDITIONS, feature_name, conditions)
         self._store.set_meta(feature_name, meta)
-        self._event_emitter.emit(EventType.POST_SET_CONDITIONS,
-                                 feature_name,
-                                 conditions)
+        self._event_emitter.emit(
+            EventType.POST_SET_CONDITIONS, feature_name, conditions
+        )

--- a/flipper/events/subscriber.py
+++ b/flipper/events/subscriber.py
@@ -11,7 +11,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from typing import Optional, Iterable
+from typing import Iterable, Optional
 
 from flipper.bucketing.base import AbstractBucketer
 from flipper.conditions import Condition
@@ -52,12 +52,10 @@ class FlipperEventSubscriber:
     def on_post_add_condition(self, flag_name: str, condition: Condition):
         pass
 
-    def on_pre_set_conditions(self, flag_name: str,
-                              conditions: Iterable[Condition]):
+    def on_pre_set_conditions(self, flag_name: str, conditions: Iterable[Condition]):
         pass
 
-    def on_post_set_conditions(self, flag_name: str,
-                               conditions: Iterable[Condition]):
+    def on_post_set_conditions(self, flag_name: str, conditions: Iterable[Condition]):
         pass
 
     def on_pre_set_client_data(self, flag_name: str, client_data: dict):

--- a/flipper/events/subscriber.py
+++ b/flipper/events/subscriber.py
@@ -11,7 +11,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from typing import Optional
+from typing import Optional, Iterable
 
 from flipper.bucketing.base import AbstractBucketer
 from flipper.conditions import Condition
@@ -50,6 +50,14 @@ class FlipperEventSubscriber:
         pass
 
     def on_post_add_condition(self, flag_name: str, condition: Condition):
+        pass
+
+    def on_pre_set_conditions(self, flag_name: str,
+                              conditions: Iterable[Condition]):
+        pass
+
+    def on_post_set_conditions(self, flag_name: str,
+                               conditions: Iterable[Condition]):
         pass
 
     def on_pre_set_client_data(self, flag_name: str, client_data: dict):

--- a/flipper/events/types.py
+++ b/flipper/events/types.py
@@ -30,6 +30,9 @@ class EventType(enum.Enum):
     PRE_ADD_CONDITION = "pre_add_condition"
     POST_ADD_CONDITION = "post_add_condition"
 
+    PRE_SET_CONDITIONS = "pre_set_conditions"
+    POST_SET_CONDITIONS = "post_set_conditions"
+
     PRE_SET_CLIENT_DATA = "pre_set_client_data"
     POST_SET_CLIENT_DATA = "post_set_client_data"
 

--- a/flipper/flag.py
+++ b/flipper/flag.py
@@ -10,7 +10,7 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable
 
 from .bucketing.base import AbstractBucketer
 from .conditions import Condition
@@ -53,3 +53,6 @@ class FeatureFlag:
 
     def set_bucketer(self, bucketer: AbstractBucketer):
         self._client.set_bucketer(self.name, bucketer)
+
+    def set_conditions(self, conditions: Iterable[Condition]):
+        self._client.set_conditions(self.name, conditions)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requirements = [
 
 setup(
     name="flipper-client",
-    version="1.0.6",
+    version="1.0.7",
     packages=find_packages(),
     license="Apache License 2.0",
     long_description=open("README.md").read(),

--- a/tests/events/test_emitter.py
+++ b/tests/events/test_emitter.py
@@ -39,6 +39,12 @@ class DummySubscriber(FlipperEventSubscriber):
     def on_post_add_condition(self, *args, **kwargs):
         self._mock.on_post_add_condition(*args, **kwargs)
 
+    def on_pre_set_conditions(self, *args, **kwargs):
+        self._mock.on_pre_set_conditions(*args, **kwargs)
+
+    def on_post_set_conditions(self, *args, **kwargs):
+        self._mock.on_post_set_conditions(*args, **kwargs)
+
     def on_pre_set_client_data(self, *args, **kwargs):
         self._mock.on_pre_set_client_data(*args, **kwargs)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,12 +1,12 @@
 import unittest
+from typing import Iterable, List, Tuple
 from unittest.mock import MagicMock
 from uuid import uuid4
 
 from flipper import Condition, FeatureFlagClient, MemoryFeatureFlagStore
 from flipper.bucketing import Percentage, PercentageBucketer
 from flipper.contrib.storage import FeatureFlagStoreMeta
-from flipper.events import EventType, FlipperEventEmitter, \
-    FlipperEventSubscriber
+from flipper.events import EventType, FlipperEventEmitter, FlipperEventSubscriber
 from flipper.exceptions import FlagDoesNotExistError
 from flipper.flag import FeatureFlag
 
@@ -141,8 +141,7 @@ class TestCreate(BaseTest):
         client_data = {"x": 10}
 
         self.client.events = events
-        self.client.create(feature_name, is_enabled=True,
-                           client_data=client_data)
+        self.client.create(feature_name, is_enabled=True, client_data=client_data)
 
         listener.assert_called_with(
             feature_name, is_enabled=True, client_data=client_data
@@ -159,8 +158,7 @@ class TestCreate(BaseTest):
         client_data = {"x": 10}
 
         self.client.events = events
-        self.client.create(feature_name, is_enabled=True,
-                           client_data=client_data)
+        self.client.create(feature_name, is_enabled=True, client_data=client_data)
 
         listener.assert_called_with(
             feature_name, is_enabled=True, client_data=client_data
@@ -474,8 +472,7 @@ class TestSetClientData(BaseTest):
 
         item = self.store.get(feature_name)
 
-        self.assertEqual({**existing_data, **new_data},
-                         item.meta["client_data"])
+        self.assertEqual({**existing_data, **new_data}, item.meta["client_data"])
 
     def test_can_override_existing_values(self):
         feature_name = self.txt()
@@ -694,14 +691,13 @@ class TestSetConditions(BaseTest):
     class Subscriber(FlipperEventSubscriber):
         def __init__(self) -> None:
             super().__init__()
-            self.events = []
+            self.events = []  # type: List[Tuple[str, str, Iterable[Condition]]]
 
         def on_pre_set_conditions(self, flag_name: str, conditions):
-            self.events.append(('pre_set_conditions', flag_name, conditions))
+            self.events.append(("pre_set_conditions", flag_name, conditions))
 
-        def on_post_set_conditions(self, flag_name: str,
-                                   conditions):
-            self.events.append(('post_set_conditions', flag_name, conditions))
+        def on_post_set_conditions(self, flag_name: str, conditions):
+            self.events.append(("post_set_conditions", flag_name, conditions))
 
     def setUp(self):
         super().setUp()
@@ -709,43 +705,30 @@ class TestSetConditions(BaseTest):
         self.client.events.register_subscriber(self.subscriber)
 
     def test_overrides_previous_conditions(self):
-        feature_name = 'FLAG'
+        feature_name = "FLAG"
         overriden_condition = Condition(value=True)
         new_conditions = [Condition(new_value=True), Condition(id__in=[1, 2])]
-        self.client.create(
-            feature_name,
-        )
+        self.client.create(feature_name)
 
         self.client.add_condition(feature_name, overriden_condition)
         self.client.set_conditions(feature_name, new_conditions)
 
-        conditions_array = self.client.get_meta(feature_name)['conditions']
+        conditions_array = self.client.get_meta(feature_name)["conditions"]
         expected_conditions_array = [
-            {
-                'new_value': [
-                    {'variable': 'new_value', 'value': True, 'operator': None},
-                ],
-            },
-            {
-
-                'id': [
-                    {'variable': 'id', 'value': [1, 2], 'operator': 'in'},
-                ]
-            }
+            {"new_value": [{"variable": "new_value", "value": True, "operator": None}]},
+            {"id": [{"variable": "id", "value": [1, 2], "operator": "in"}]},
         ]
 
         self.assertEqual(expected_conditions_array, conditions_array)
 
     def test_events_are_emitted(self):
-        feature_name = 'FLAG'
+        feature_name = "FLAG"
         new_conditions = [Condition(new_value=True), Condition(id__in=[1, 2])]
 
-        self.client.create(
-            feature_name,
-        )
+        self.client.create(feature_name)
 
         self.client.set_conditions(feature_name, new_conditions)
         assert self.subscriber.events == [
-            ('pre_set_conditions', feature_name, new_conditions),
-            ('post_set_conditions', feature_name, new_conditions),
+            ("pre_set_conditions", feature_name, new_conditions),
+            ("post_set_conditions", feature_name, new_conditions),
         ]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,7 +5,8 @@ from uuid import uuid4
 from flipper import Condition, FeatureFlagClient, MemoryFeatureFlagStore
 from flipper.bucketing import Percentage, PercentageBucketer
 from flipper.contrib.storage import FeatureFlagStoreMeta
-from flipper.events import EventType, FlipperEventEmitter
+from flipper.events import EventType, FlipperEventEmitter, \
+    FlipperEventSubscriber
 from flipper.exceptions import FlagDoesNotExistError
 from flipper.flag import FeatureFlag
 
@@ -140,7 +141,8 @@ class TestCreate(BaseTest):
         client_data = {"x": 10}
 
         self.client.events = events
-        self.client.create(feature_name, is_enabled=True, client_data=client_data)
+        self.client.create(feature_name, is_enabled=True,
+                           client_data=client_data)
 
         listener.assert_called_with(
             feature_name, is_enabled=True, client_data=client_data
@@ -157,7 +159,8 @@ class TestCreate(BaseTest):
         client_data = {"x": 10}
 
         self.client.events = events
-        self.client.create(feature_name, is_enabled=True, client_data=client_data)
+        self.client.create(feature_name, is_enabled=True,
+                           client_data=client_data)
 
         listener.assert_called_with(
             feature_name, is_enabled=True, client_data=client_data
@@ -471,7 +474,8 @@ class TestSetClientData(BaseTest):
 
         item = self.store.get(feature_name)
 
-        self.assertEqual({**existing_data, **new_data}, item.meta["client_data"])
+        self.assertEqual({**existing_data, **new_data},
+                         item.meta["client_data"])
 
     def test_can_override_existing_values(self):
         feature_name = self.txt()
@@ -684,3 +688,64 @@ class TestSetBucketer(BaseTest):
         self.client.set_bucketer(feature_name, bucketer)
 
         listener.assert_called_once_with(feature_name, bucketer)
+
+
+class TestSetConditions(BaseTest):
+    class Subscriber(FlipperEventSubscriber):
+        def __init__(self) -> None:
+            super().__init__()
+            self.events = []
+
+        def on_pre_set_conditions(self, flag_name: str, conditions):
+            self.events.append(('pre_set_conditions', flag_name, conditions))
+
+        def on_post_set_conditions(self, flag_name: str,
+                                   conditions):
+            self.events.append(('post_set_conditions', flag_name, conditions))
+
+    def setUp(self):
+        super().setUp()
+        self.subscriber = self.Subscriber()
+        self.client.events.register_subscriber(self.subscriber)
+
+    def test_overrides_previous_conditions(self):
+        feature_name = 'FLAG'
+        overriden_condition = Condition(value=True)
+        new_conditions = [Condition(new_value=True), Condition(id__in=[1, 2])]
+        self.client.create(
+            feature_name,
+        )
+
+        self.client.add_condition(feature_name, overriden_condition)
+        self.client.set_conditions(feature_name, new_conditions)
+
+        conditions_array = self.client.get_meta(feature_name)['conditions']
+        expected_conditions_array = [
+            {
+                'new_value': [
+                    {'variable': 'new_value', 'value': True, 'operator': None},
+                ],
+            },
+            {
+
+                'id': [
+                    {'variable': 'id', 'value': [1, 2], 'operator': 'in'},
+                ]
+            }
+        ]
+
+        self.assertEqual(expected_conditions_array, conditions_array)
+
+    def test_events_are_emitted(self):
+        feature_name = 'FLAG'
+        new_conditions = [Condition(new_value=True), Condition(id__in=[1, 2])]
+
+        self.client.create(
+            feature_name,
+        )
+
+        self.client.set_conditions(feature_name, new_conditions)
+        assert self.subscriber.events == [
+            ('pre_set_conditions', feature_name, new_conditions),
+            ('post_set_conditions', feature_name, new_conditions),
+        ]

--- a/tests/test_flag.py
+++ b/tests/test_flag.py
@@ -253,7 +253,8 @@ class TestSetClientData(BaseTest):
 
         item = self.store.get(self.name)
 
-        self.assertEqual({**existing_data, **new_data}, item.meta["client_data"])
+        self.assertEqual({**existing_data, **new_data},
+                         item.meta["client_data"])
 
     def test_can_override_existing_values(self):
         existing_data = {"existing_key": self.txt()}
@@ -349,3 +350,30 @@ class TestSetBucketer(BaseTest):
         meta = self.flag.get_meta()
 
         self.assertEqual(bucketer.to_dict(), meta["bucketer"])
+
+
+class TestSetConditions(BaseTest):
+    def test_overrides_previous_conditions(self):
+        self.store.create(self.name)
+        overriden_condition = Condition(value=True)
+        new_conditions = [Condition(new_value=True), Condition(id__in=[1, 2])]
+
+        self.flag.add_condition(overriden_condition)
+        self.flag.set_conditions(new_conditions)
+
+        conditions_array = self.flag.get_meta()['conditions']
+        expected_conditions_array = [
+            {
+                'new_value': [
+                    {'variable': 'new_value', 'value': True, 'operator': None},
+                ],
+            },
+            {
+
+                'id': [
+                    {'variable': 'id', 'value': [1, 2], 'operator': 'in'},
+                ]
+            }
+        ]
+
+        self.assertEqual(expected_conditions_array, conditions_array)

--- a/tests/test_flag.py
+++ b/tests/test_flag.py
@@ -253,8 +253,7 @@ class TestSetClientData(BaseTest):
 
         item = self.store.get(self.name)
 
-        self.assertEqual({**existing_data, **new_data},
-                         item.meta["client_data"])
+        self.assertEqual({**existing_data, **new_data}, item.meta["client_data"])
 
     def test_can_override_existing_values(self):
         existing_data = {"existing_key": self.txt()}
@@ -361,19 +360,10 @@ class TestSetConditions(BaseTest):
         self.flag.add_condition(overriden_condition)
         self.flag.set_conditions(new_conditions)
 
-        conditions_array = self.flag.get_meta()['conditions']
+        conditions_array = self.flag.get_meta()["conditions"]
         expected_conditions_array = [
-            {
-                'new_value': [
-                    {'variable': 'new_value', 'value': True, 'operator': None},
-                ],
-            },
-            {
-
-                'id': [
-                    {'variable': 'id', 'value': [1, 2], 'operator': 'in'},
-                ]
-            }
+            {"new_value": [{"variable": "new_value", "value": True, "operator": None}]},
+            {"id": [{"variable": "id", "value": [1, 2], "operator": "in"}]},
         ]
 
         self.assertEqual(expected_conditions_array, conditions_array)


### PR DESCRIPTION
This PR adds set_conditions feature.
This feature aims to add the possibility of editing or overriding conditions, since the API currently only supports the add_condition.

2 new events are being emitted:
PRE_SET_CONDITIONS
POST_SET_CONDITIONS