### PR TITLE
Change LRU cache implementation to be cachetools instead of old lib

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 combine_as_imports=True
 line_length=88
-known_third_party = boto3,fakeredis,lruttl,moto,pyee,pytest,redis,setuptools,thrift
+known_third_party = boto3,cachetools,fakeredis,moto,pyee,pytest,redis,setuptools,thrift

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,11 @@ repos:
     hooks:
       - id: insert-license
         files: flipper|flipper_thrift
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.7
+    hooks:
+      - id: flake8
+        exclude: flipper_thrift|flipper_client\.egg_info|build|.circleci
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: master
     hooks:
@@ -35,8 +40,6 @@ repos:
       - id: trailing-whitespace
         exclude: flipper_thrift|flipper_client\.egg_info|build|.circleci
       - id: check-ast
-        exclude: flipper_thrift|flipper_client\.egg_info|build|.circleci
-      - id: flake8
         exclude: flipper_thrift|flipper_client\.egg_info|build|.circleci
   - repo: https://github.com/PyCQA/bandit
     rev: master

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 requirements = [
     "fakeredis~=0.11.0",
-    "lru-ttl~=0.0.6",
+    "cachetools~=4.1.0",
     "python-consul~=1.0.1",
     "redis~=2.10.6",
     "thrift~=0.11.0",

--- a/tests/contrib/test_cached.py
+++ b/tests/contrib/test_cached.py
@@ -127,6 +127,19 @@ class TestGet(BaseTest):
 
         self.assertIsNotNone(fast.get(feature_name))
 
+    def test_it_should_be_able_to_cache_flags_that_do_not_exist(self):
+        slow = MagicMock()
+        fast = CachedFeatureFlagStore(slow)
+
+        feature_name = self.txt()
+
+        fast.get(feature_name)
+        fast.get(feature_name)
+        fast.get(feature_name)
+        fast.get(feature_name)
+
+        slow.get.assert_called_once_with(feature_name)
+
 
 class TestSet(BaseTest):
     def test_sets_value_correctly(self):


### PR DESCRIPTION
The `lru-ttl` library did not have a way to distinguish between keys with values that are `None` and keys that don't exist in the cache. This was causing a major performance problem if the flag does not exist in the store, since those values don't get cached. By switching to the `cachetools` library, we can take advantage of its ability to cache `None` values. This should be a big performance win for cases where flags don't exist in the store.