### PR TITLE
Avoid race condition that happens when cache entry expires while checking

### DIFF
--- a/flipper/contrib/cached.py
+++ b/flipper/contrib/cached.py
@@ -49,8 +49,10 @@ class CachedFeatureFlagStore(AbstractFeatureFlagStore):
         return item
 
     def get(self, feature_name: str) -> Optional[FeatureFlagStoreItem]:
-        if feature_name in self._cache:
+        try:
             return self._cache[feature_name]
+        except KeyError:
+            pass
 
         item = self._store.get(feature_name)
         self._cache[feature_name] = item

--- a/tests/contrib/test_cached.py
+++ b/tests/contrib/test_cached.py
@@ -114,14 +114,23 @@ class TestGet(BaseTest):
 
         fast.create(feature_name)
 
-        get = fast._cache.get
+        class CacheWrapper:
+            def __init__(self, wrapped):
+                self.wrapped = wrapped
 
-        def slow_get(key):
-            result = get(key)
-            sleep(0.02)
-            return result
+            def __contains__(self, key):
+                result = key in self.wrapped
+                sleep(0.02)
+                return result
 
-        fast._cache.get = slow_get
+            def __getitem__(self, key):
+                return self.wrapped[key]
+
+            def __setitem__(self, key, value):
+                self.wrapped[key] = value
+
+        cache = fast._cache
+        fast._cache = CacheWrapper(cache)
 
         fast.set(feature_name, 1)
 


### PR DESCRIPTION
It is possible for a cached entry to expire between the time that we check if the cache has an entry and when we read that entry. This was throwing `KeyError` on rare occasions. I've fixed this by attempting to read from the cache and catching any key errors (EAFTP). This means we don't have two different operations to read from the cache and this race condition is impossible.

I also fixed a test that became obsolete when we swapped cache libs.