### PR TITLE
Update-redis version to support python 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ client = FeatureFlagClient(store)
 
 ## Usage with Redis backend
 
-To connect flipper to redis just create an instance of `StrictRedis` and supply it to the `RedisFeatureFlagStore` backend. Features will be tracked under the base key your provide (default is `features`).
+To connect flipper to redis just create an instance of `Redis` and supply it to the `RedisFeatureFlagStore` backend. Features will be tracked under the base key your provide (default is `features`).
 
 Keep in mind, this will do a network call every time a feature flag is checked, so you may want to add a local in-memory cache (see below).
 
@@ -563,7 +563,7 @@ import redis
 from flipper import FeatureFlagClient, RedisFeatureFlagStore
 
 
-r = redis.StrictRedis(host='localhost', port=6379, db=0)
+r = redis.Redis(host='localhost', port=6379, db=0)
 
 # default base_key is 'features'
 store = RedisFeatureFlagStore(r, base_key='feature-flags')
@@ -584,7 +584,7 @@ from flipper import (
 )
 
 
-r = redis.StrictRedis(host='localhost', port=6379, db=0)
+r = redis.Redis(host='localhost', port=6379, db=0)
 
 store = RedisFeatureFlagStore(r)
 
@@ -697,8 +697,8 @@ from flipper import (
 )
 
 
-primary_redis = redis.StrictRedis(host='localhost', port=6379, db=0)
-backup_redis = redis.StrictRedis(host='localhost', port=6379, db=1)
+primary_redis = redis.Redis(host='localhost', port=6379, db=0)
+backup_redis = redis.Redis(host='localhost', port=6379, db=1)
 
 primary = RedisFeatureFlagStore(primary_redis, base_key='feature-flags')
 replica = RedisFeatureFlagStore(backup_redis, base_key='feature-flags')

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from setuptools import find_packages, setup
 
 requirements = [
-    "fakeredis~=0.11.0",
     "cachetools~=4.1.0",
     "python-consul~=1.0.1",
     "redis>=2.10.6,<4",
@@ -21,6 +20,7 @@ setup(
     install_requires=requirements,
     extras_require={
         "dev": [
+            "fakeredis~=0.11.0",
             "pytest~=3.6.2",
             "ipython",
             "thrift",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ requirements = [
     "fakeredis~=0.11.0",
     "cachetools~=4.1.0",
     "python-consul~=1.0.1",
-    "redis>=2.10.6,<3.6",
+    "redis>=2.10.6,<4",
     "thrift~=0.13.0",
     "boto3~=1.9.83",
     "pyee==6.0.0",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ requirements = [
     "fakeredis~=0.11.0",
     "cachetools~=4.1.0",
     "python-consul~=1.0.1",
-    "redis~=2.10.6",
+    "redis>=2.10.6,<3.6",
     "thrift~=0.13.0",
     "boto3~=1.9.83",
     "pyee==6.0.0",
@@ -13,7 +13,7 @@ requirements = [
 
 setup(
     name="flipper-client",
-    version="1.2.3",
+    version="1.2.4",
     packages=find_packages(),
     license="Apache License 2.0",
     long_description=open("README.md").read(),


### PR DESCRIPTION
When porting a package using `flipper-client` to python 3.8 we encounter some incompatible versions of redis. 

`flipper-client 1.2.3 has requirement redis~=2.10.6, but you have redis 3.5.3.`

Reviewed [upgrade suggestions ](https://github.com/andymccurdy/redis-py#upgrading-from-redis-py-2x-to-30)
- StrictRedis renamed to Redis, but still aliased to StrictRedis, no changes required, but updated README.md
- No uses of SETEX, LREM, TTL, PTTL, MSET, MSETNX, ZINCRBY or ZADD
- redis-py 3.0 only accepts user data as bytes, strings or numbers (ints, longs and floats). We [already serialize inputs](https://github.com/carta/flipper-client/blob/master/flipper/contrib/storage/item.py#L36)
- We do not reference LuaLock or use a lock context manager