### PR TITLE
Fix a bug with long ramps

### DIFF
--- a/flipper/bucketing/percentage/linear_ramp_percentage.py
+++ b/flipper/bucketing/percentage/linear_ramp_percentage.py
@@ -48,8 +48,8 @@ class LinearRampPercentage(AbstractPercentage):
         return (self._final_value - self._initial_value) / self._ramp_duration
 
     @property
-    def dt(self) -> int:
-        return (datetime.now() - self._initial_time).seconds
+    def dt(self) -> float:
+        return (datetime.now() - self._initial_time).total_seconds()
 
     def to_dict(self) -> Dict[str, Any]:
         return {

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ requirements = [
 
 setup(
     name="flipper-client",
-    version="1.2.4",
+    version="1.2.5",
     packages=find_packages(),
     license="Apache License 2.0",
     long_description=open("README.md").read(),

--- a/tests/bucketing/percentage/test_base.py
+++ b/tests/bucketing/percentage/test_base.py
@@ -1,0 +1,20 @@
+from unittest import TestCase
+
+from flipper.bucketing import Percentage
+
+
+class TestLessThanOrEqualTo(TestCase):
+    def test_when_comparison_is_greater_than_value_it_returns_false(self):
+        percentage = Percentage(0.5)
+
+        self.assertFalse(0.6 <= percentage)
+
+    def test_when_comparison_is_equal_to_value_it_returns_true(self):
+        percentage = Percentage(0.5)
+
+        self.assertTrue(0.5 <= percentage)
+
+    def test_when_comparison_is_less_then_value_it_returns_true(self):
+        percentage = Percentage(0.5)
+
+        self.assertTrue(0.4 <= percentage)

--- a/tests/bucketing/percentage/test_linear_ramp_percentage.py
+++ b/tests/bucketing/percentage/test_linear_ramp_percentage.py
@@ -54,6 +54,35 @@ class TestValue(unittest.TestCase):
 
         self.assertEqual(expected, percentage.value)
 
+    @patch("flipper.bucketing.percentage.linear_ramp_percentage.datetime")
+    def test_when_ramp_duration_is_longer_than_one_hour_and_ramp_has_completed_it_computes_value_correctly(  # noqa: E501
+        self, mock_datetime
+    ):
+        now = datetime(2020, 10, 28)
+
+        mock_datetime.now.return_value = now
+        mock_datetime.fromtimestamp = datetime.fromtimestamp
+
+        initial_value = 0.1
+        final_value = 1
+        ramp_duration = 1601314960
+        expected_percentage = 1
+
+        dt = timedelta(seconds=ramp_duration * expected_percentage)
+        initial_time = int((now - dt).timestamp())
+
+        percentage = LinearRampPercentage(
+            initial_value=initial_value,
+            final_value=final_value,
+            ramp_duration=ramp_duration,
+            initial_time=initial_time,
+        )
+
+        value_delta = final_value - initial_value
+        expected = value_delta * expected_percentage + initial_value
+
+        self.assertEqual(expected, percentage.value)
+
 
 class TestToDict(unittest.TestCase):
     def test_returns_correct_values(self):


### PR DESCRIPTION
When calculating the delta between the initial time and current time in a linear ramp percentage, we were accidentally using the `seconds` attribute of the `timedelta` instead of the `total_seconds()` method, which gives the entire duration rather than just the seconds part. This was causing a bug where ramps of longer than an hour would never finish.