### PR TITLE
Supporting OR conditions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ install:
 
 
 install-dev:
+    pip install --upgrade pip
 	pip install -e .[dev]
 	pre-commit install
 	pre-commit install-hooks

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ features.is_enabled(MY_FEATURE, is_administrator=False) # returns False
 
 ```
 
-If a check has one Condition with multiple checks, both need to be satisfied for `is_enabled` to return true.
+If a flag has one Condition with multiple checks, both need to be satisfied for `is_enabled` to return true.
 
 Example:
 
@@ -180,7 +180,7 @@ flag.add_condition(
 flag.is_enabled(is_horse_lover=False, horse_type='Stallion') # returns False
 ```
 
-If a check has multiple conditions, `is_enabled` will return true if any of them is satisfied.
+If a flag has multiple conditions, `is_enabled` will return true if any of them is satisfied.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ flag.add_condition(
     )
 )
 
-flag.is_enabled(is_horse_lover=True, horse_type__in=['Stallion', 'Mare'])
+flag.is_enabled(is_horse_lover=True, horse_type='Stallion')
 ```
 
 If a check has multiple conditions, `is_enabled` will return TRUE if any of them is satisfied (OR operation).
@@ -184,7 +184,7 @@ If a check has multiple conditions, `is_enabled` will return TRUE if any of them
 flag.add_condition(Condition(is_horse_lover=True))
 flag.add_condition(Condition(horse_type__in=['Stallion', 'Mare'])
 
-flag.is_enabled(is_horse_lover=True, horse_type__in=['Stallion', 'Mare'])
+flag.is_enabled(is_horse_lover=True, horse_type='Stallion')
 ```
 
 **`set_bucketer(feature_name: str, bucketer: Bucketer) -> void`**

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ features.get_meta(MY_FEATURE)
 
 **`add_condition(feature_name: str, condition: Condition) -> void`**
 
-Adds a condition to for enabled checks, such that `is_enabled` will only return true if all the conditions are satisfied when it is called.
+Adds a condition to for enabled checks, such that `is_enabled` will return true if any of the conditions are satisfied when it is called.
 
 Example:
 
@@ -163,6 +163,28 @@ features.add_condition(MY_FEATURE, Condition(is_administrator=True))
 features.is_enabled(MY_FEATURE, is_administrator=True) # returns True
 features.is_enabled(MY_FEATURE, is_administrator=False) # returns False
 
+```
+
+If a check has one Condition with multiple checks, both need to be satisfied for `is_enabled` to return true.
+
+```python
+flag.add_condition(
+    Condition(
+        is_horse_lover=True,
+        horse_type__in=['Stallion', 'Mare'],
+    )
+)
+
+flag.is_enabled(is_horse_lover=True, horse_type__in=['Stallion', 'Mare'])
+```
+
+If a check has multiple conditions, `is_enabled` will return TRUE if any of them is satisfied (OR operation).
+
+```python
+flag.add_condition(Condition(is_horse_lover=True))
+flag.add_condition(Condition(horse_type__in=['Stallion', 'Mare'])
+
+flag.is_enabled(is_horse_lover=True, horse_type__in=['Stallion', 'Mare'])
 ```
 
 **`set_bucketer(feature_name: str, bucketer: Bucketer) -> void`**

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ flag.add_condition(
 flag.is_enabled(is_horse_lover=True, horse_type='Stallion')
 ```
 
-If a check has multiple conditions, `is_enabled` will return TRUE if any of them is satisfied (OR operation).
+If a check has multiple conditions, `is_enabled` will return TRUE if any of them is satisfied.
 
 ```python
 flag.add_condition(Condition(is_horse_lover=True))

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ features.is_enabled(MY_FEATURE, is_administrator=False) # returns False
 
 If a check has one Condition with multiple checks, both need to be satisfied for `is_enabled` to return true.
 
+Example:
+
 ```python
 flag.add_condition(
     Condition(
@@ -175,16 +177,18 @@ flag.add_condition(
     )
 )
 
-flag.is_enabled(is_horse_lover=True, horse_type='Stallion')
+flag.is_enabled(is_horse_lover=False, horse_type='Stallion') # returns False
 ```
 
 If a check has multiple conditions, `is_enabled` will return TRUE if any of them is satisfied.
+
+Example:
 
 ```python
 flag.add_condition(Condition(is_horse_lover=True))
 flag.add_condition(Condition(horse_type__in=['Stallion', 'Mare'])
 
-flag.is_enabled(is_horse_lover=True, horse_type='Stallion')
+flag.is_enabled(is_horse_lover=False, horse_type='Stallion') # returns True
 ```
 
 **`set_bucketer(feature_name: str, bucketer: Bucketer) -> void`**

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ flag.add_condition(
 flag.is_enabled(is_horse_lover=False, horse_type='Stallion') # returns False
 ```
 
-If a check has multiple conditions, `is_enabled` will return TRUE if any of them is satisfied.
+If a check has multiple conditions, `is_enabled` will return true if any of them is satisfied.
 
 Example:
 

--- a/flipper/conditions/condition.py
+++ b/flipper/conditions/condition.py
@@ -34,6 +34,16 @@ class Condition:
         return parsed_checks
 
     def check(self, **checks) -> bool:
+        """
+        When a Condition has multiple checks it works like an AND
+
+        flag.add_condition(
+            Condition(
+                is_horse_lover=True,
+                horse_type__in=['Stallion', 'Mare'],
+            )
+        )
+        """
         for check_name, check_value in checks.items():
             checkers = self._checks[check_name]
 

--- a/flipper/contrib/storage/item.py
+++ b/flipper/contrib/storage/item.py
@@ -63,7 +63,13 @@ class FeatureFlagStoreItem:
         return True
 
     def _all_conditions_satisfied(self, **conditions) -> bool:
-        return all(c.check(**conditions) for c in self._meta.conditions)
+        """
+        Independent calls to add_condition works like an OR
+
+        flag.add_condition(Condition(is_horse_lover=True))
+        flag.add_condition(Condition(horse_type__in=['Stallion', 'Mare'])
+        """
+        return any(c.check(**conditions) for c in self._meta.conditions)
 
     def _has_bucketer(self) -> bool:
         return self._meta.bucketer.get_type() != NoOpBucketer.get_type()

--- a/tests/conditions/test_condition.py
+++ b/tests/conditions/test_condition.py
@@ -158,6 +158,20 @@ class TestCheck(BaseTest):
 
         self.assertTrue(condition.check(foo=True, bar=False, herp=20, derp=5))
 
+    def test_returns_true_when_a_check_is_removed_but_other_checks_are_met(self):
+        condition = Condition(
+            foo=True,
+            baz__gt=99,
+            baz__lt=103,
+            herp__gte=10,
+            herp__lte=20,
+            derp__ne=2,
+            derp__in=[2, 43, 5, 8],
+            derp__not_in=[8, 1000],
+        )
+
+        self.assertTrue(condition.check(foo=True, bar=False, baz=101, herp=20, derp=5))
+
 
 class TestToDict(BaseTest):
     def test_includes_all_checks(self):

--- a/tests/conditions/test_condition.py
+++ b/tests/conditions/test_condition.py
@@ -143,6 +143,21 @@ class TestCheck(BaseTest):
 
         self.assertFalse(condition.check(foo=True, bar=False, baz=101, herp=21, derp=5))
 
+    def test_returns_true_when_a_value_is_missing_but_other_checks_are_met(self):
+        condition = Condition(
+            foo=True,
+            bar=False,
+            baz__gt=99,
+            baz__lt=103,
+            herp__gte=10,
+            herp__lte=20,
+            derp__ne=2,
+            derp__in=[2, 43, 5, 8],
+            derp__not_in=[8, 1000],
+        )
+
+        self.assertTrue(condition.check(foo=True, bar=False, herp=20, derp=5))
+
 
 class TestToDict(BaseTest):
     def test_includes_all_checks(self):

--- a/tests/contrib/storage/test_item.py
+++ b/tests/contrib/storage/test_item.py
@@ -120,11 +120,17 @@ class TestIsEnabled(BaseTest):
         item = FeatureFlagStoreItem(self.txt(), True, meta)
         self.assertFalse(item.is_enabled(foo=False))
 
-    def test_is_false_if_one_of_many_conditions_are_not_matched(self):
+    def test_is_false_if_all_of_many_conditions_are_not_matched(self):
         conditions = [Condition(foo=True), Condition(x=9)]
         meta = FeatureFlagStoreMeta(self.now, conditions=conditions)
         item = FeatureFlagStoreItem(self.txt(), True, meta)
-        self.assertFalse(item.is_enabled(foo=True, x=11))
+        self.assertFalse(item.is_enabled(foo=False, x=11))
+
+    def test_is_true_if_one_of_many_conditions_are_not_matched(self):
+        conditions = [Condition(foo=True), Condition(x=9)]
+        meta = FeatureFlagStoreMeta(self.now, conditions=conditions)
+        item = FeatureFlagStoreItem(self.txt(), True, meta)
+        self.assertTrue(item.is_enabled(foo=True, x=11))
 
     def test_is_true_if_all_of_many_conditions_are_matched(self):
         conditions = [Condition(foo=True), Condition(x=9)]


### PR DESCRIPTION
Right now there are no differences between 

```
flag.add_condition(Condition(is_horse_lover=True))
flag.add_condition(Condition(horse_type__in=['Stallion', 'Mare'])
```

and

```
flag.add_condition(
    Condition(
        is_horse_lover=True,
        horse_type__in=['Stallion', 'Mare'],
    )
)
```

when calling

`flag.is_enabled(is_horse_lover=True, horse_type='Stallion')`

The only way to simulate an OR condition is to either call flipper twice when checking

`flag.is_enabled(is_horse_lover=True) or flag.is_enabled(horse_type='Stallion')`

However, it is not possible to disable one of the conditions because if removed from the flag the corresponding check becomes true for everyone instead of false.

This means the only real workaround is to add multiple independent feature flags and handle the OR manually.

In this PR we add support for OR on the flipper side by making multiple conditions work as an OR while a condition with multiple checks works as an AND.

Question: Should this change bump version to 2.0.0?