### PR TITLE
Allow deleting a flag that does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ flag.disable()
 **`destroy() -> void`**
 
 Destroys the flag. Subsequent calls to `is_enabled` should return false.
+What happens when the flag does not exist is left up to the underlying store as an implementation detail.
 
 Example:
 

--- a/flipper/client.py
+++ b/flipper/client.py
@@ -98,7 +98,6 @@ class FeatureFlagClient:
         self._store.set(feature_name, False)
         self._event_emitter.emit(EventType.POST_DISABLE, feature_name)
 
-    @flag_must_exist
     def destroy(self, feature_name: str):
         self._event_emitter.emit(EventType.PRE_DESTROY, feature_name)
         self._store.delete(feature_name)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -205,11 +205,12 @@ class TestDestroy(BaseTest):
 
         self.assertFalse(self.client.is_enabled(feature_name))
 
-    def test_raises_for_nonexistent_flag(self):
+    def test_noops_for_nonexistent_flag(self):
         feature_name = self.txt()
 
-        with self.assertRaises(FlagDoesNotExistError):
-            self.client.destroy(feature_name)
+        self.client.destroy(feature_name)
+
+        self.assertFalse(self.client.exists(feature_name))
 
     def test_emits_pre_destroy_event(self):
         feature_name = self.txt()

--- a/tests/test_flag.py
+++ b/tests/test_flag.py
@@ -125,9 +125,12 @@ class TestDestroy(BaseTest):
 
         client.destroy.assert_called_once_with(self.name)
 
-    def test_raises_for_nonexistent_flag(self):
-        with self.assertRaises(FlagDoesNotExistError):
-            self.flag.destroy()
+    def test_client_is_called_for_nonexistent_flag(self):
+        client = MagicMock()
+        flag = FeatureFlag(self.name, client)
+        flag.destroy()
+
+        client.destroy.assert_called_once_with(self.name)
 
 
 class TestEnable(BaseTest):


### PR DESCRIPTION
The added restriction in the `client.destroy` method that the flag must exist renders it no longer idempotent which can be restrictive.

For example - it is possible for the Redis store `list` call to return duplicate keys ([see docs](https://redis.io/commands/scan#scan-guarantees)). If iterating on the list and deleting each flag, then on the second attempt to delete a flag that happened to be duplicated would result in an error when it can just no-op instead.

This PR removes this restriction and instead leaves it up to the underlying store as an implementation detail. (Currently all of the supported stores provided with this project simply no-op so this isn't a breaking change).