### PR TITLE
Bump cachetools to 4.2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ requirements = [
 
 setup(
     name="flipper-client",
-    version="1.2.7",
+    version="1.2.8",
     packages=find_packages(),
     license="Apache License 2.0",
     long_description=open("README.md").read(),

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 requirements = [
-    "cachetools~=4.1",
+    "cachetools~=4.2.1",
     "python-consul~=1.0",
     "redis>=2.10.6,<4",
     "thrift~=0.13",


### PR DESCRIPTION
The latest authz client package requires cachetools 4.2.1: https://github.com/carta/authz-python/blob/9e17f5f789a074997c1fb04585a446efcae082d2/requirements/release.txt#L20

This will unblock upgrading to the latest authz client in carta-web