### PR TITLE
fix(postgreSQL): fix bug when using psycopg's binary or c version

### DIFF
--- a/flipper/contrib/postgresql.py
+++ b/flipper/contrib/postgresql.py
@@ -119,7 +119,7 @@ class PostgreSQLFeatureFlagStore(AbstractFeatureFlagStore):
 
         if not row:
             return None
-        return FeatureFlagStoreItem.deserialize(row[0].tobytes())
+        return FeatureFlagStoreItem.deserialize(bytes(row[0]))
 
     def set(self, feature_name: str, is_enabled: bool) -> None:
         existing = self.get(feature_name)
@@ -145,7 +145,7 @@ class PostgreSQLFeatureFlagStore(AbstractFeatureFlagStore):
             rows = conn.execute(query).fetchall()
 
         for row in rows:
-            yield FeatureFlagStoreItem.deserialize(row[0].tobytes())
+            yield FeatureFlagStoreItem.deserialize(bytes(row[0]))
 
     def set_meta(self, feature_name: str, meta: FeatureFlagStoreMeta) -> None:
         existing = self.get(feature_name)


### PR DESCRIPTION
My contribution had a bug, I tested everything with the [pure python installation](https://www.psycopg.org/psycopg3/docs/basic/install.html#pure-python-installation) of psycopg, which returns a memory view (it has the `to_bytes` method), but with the C and Binary installation it returns bytes so it errors out. This fixes it.

Thanks! :raised_hands: 
