### PR TITLE
feat(deps): Use cachetools v5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 requirements = [
-    "cachetools~=5.3.0",
+    "cachetools>=4.2.1,<6"
     "python-consul~=1.0",
     "redis>=2.10.6,<5",
     "thrift~=0.13",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ requirements = [
 
 setup(
     name="flipper-client",
-    version="1.3.1",
+    version="1.3.2",
     packages=find_packages(),
     license="Apache License 2.0",
     long_description=open("README.md").read(),

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 requirements = [
-    "cachetools~=4.2.1",
+    "cachetools~=5.3.0",
     "python-consul~=1.0",
     "redis>=2.10.6,<5",
     "thrift~=0.13",


### PR DESCRIPTION
This change allows consumers to switch to a higher version of cachetools; fortunately there are no breaking changes in cachetools that impact this library.

See cachetools changelog: https://github.com/tkem/cachetools/blob/master/CHANGELOG.rst