### PR TITLE
Fix condition checking logic

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     hooks:
       - id: insert-license
         files: flipper|flipper_thrift
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
       - id: flake8

--- a/flipper/conditions/condition.py
+++ b/flipper/conditions/condition.py
@@ -34,11 +34,17 @@ class Condition:
         return parsed_checks
 
     def check(self, **checks) -> bool:
-        for check_name, check_value in checks.items():
-            checkers = self._checks[check_name]
+        # Ensure all required variables are present in the provided checks
+        required_variables = set(self._checks.keys())
+        provided_variables = set(checks.keys())
 
-            for checker in checkers:
-                if checker.check(check_value) is False:
+        if not required_variables.issubset(provided_variables):
+            return False
+
+        # Verify all conditions are met for the provided variables
+        for variable, value in checks.items():
+            for condition in self._checks.get(variable, []):
+                if not condition.check(value):
                     return False
         return True
 

--- a/tests/conditions/test_condition.py
+++ b/tests/conditions/test_condition.py
@@ -128,10 +128,15 @@ class TestCheck(BaseTest):
 
         self.assertFalse(condition.check(foo=True, baz=False))
 
-    def test_empty_conditions_return_false(self):
+    def test_empty_conditions_check_return_false(self):
         condition = Condition(foo=True)
 
         self.assertFalse(condition.check())
+
+    def test_no_conditions_set_but_conditions_checked_return_true(self):
+        condition = Condition()
+
+        self.assertTrue(condition.check(foo=True))
 
     def test_returns_true_when_all_checks_are_met(self):
         condition = Condition(

--- a/tests/conditions/test_condition.py
+++ b/tests/conditions/test_condition.py
@@ -113,6 +113,26 @@ class TestCheck(BaseTest):
 
         self.assertFalse(condition.check(foo=3))
 
+    def test_when_check_different_condition_than_set_then_false(self):
+        condition = Condition(foo__in=[1, 2, 3])
+
+        self.assertFalse(condition.check(bar=4))
+
+    def test_multiple_unrelated_conditions_return_false(self):
+        condition = Condition(foo=True)
+
+        self.assertFalse(condition.check(bar=True, baz=False))
+
+    def test_partial_matching_conditions(self):
+        condition = Condition(foo=True, bar=False)
+
+        self.assertFalse(condition.check(foo=True, baz=False))
+
+    def test_empty_conditions_return_false(self):
+        condition = Condition(foo=True)
+
+        self.assertFalse(condition.check())
+
     def test_returns_true_when_all_checks_are_met(self):
         condition = Condition(
             foo=True,


### PR DESCRIPTION
# Problem
The `Condition.check()` method incorrectly returned `True` when provided with missing or unrelated parameters.

## Impact
This could lead to incorrect condition evaluations in production, potentially enabling feature flags when criteria weren't actually met.

# Solution
Modified `check()` to verify all required variables are present before evaluation.

The fix ensures conditions only evaluate to `True` when all required variables are present and all conditions are satisfied.
